### PR TITLE
switching to a neutral indicator for missing tracking issue

### DIFF
--- a/index.md
+++ b/index.md
@@ -26,7 +26,7 @@ integration in various XMPP clients.
     <td>
       {% if client.tracking_issue %}
       <a href="{{ client.tracking_issue }}">✪</a>
-      {% else %}😢{% endif %}
+      {% else %}–{% endif %}
     </td>
     <td>
       {% if client.bountysource %}


### PR DESCRIPTION
at least to me, the motivation for calling a missing feature request in a ticket tracker a sad thing is a little mysterious. i guess a software project could be organized without using an issue tracker and still do a good job. or someone could send a patch without first opening an issue...
so here i propose switching to something neutral for that.