### PR TITLE
Fix unreasonable status of Miranda NG

### DIFF
--- a/_data/clients/miranda_ng.yml
+++ b/_data/clients/miranda_ng.yml
@@ -5,4 +5,4 @@ bountysource: 32298989
 work_in_progress: yes
 testing: yes
 done: no
-status: 80
+status: 67


### PR DESCRIPTION
Looking at [#529](https://github.com/miranda-ng/miranda-ng/issues/529) at Miranda NG repo, seems they do have a working version of OMEMO, but things like showing fingerprints are not implemented yet.

This is close to the status Dino folks have, but they are stuck at 67%, when Miranda has 80%. This is probably unreasonable.