### PR TITLE
Add Xabber Web to the list

### DIFF
--- a/_data/clients/xabber_web.yml
+++ b/_data/clients/xabber_web.yml
@@ -1,0 +1,5 @@
+name: Xabber Web
+url: https://web.xabber.com
+tracking_issue: https://github.com/redsolution/xabber-web/issues/3
+work_in_progress: no
+status: 0


### PR DESCRIPTION
[Xabber Web](https://web.xabber.com) is a relatively new web XMPP client, but it's probably going to rock. :-)

There is a [tracking issue](https://github.com/redsolution/xabber-web/issues/3) on GitHub. The work hasn't been started yet, though.