### PR TITLE
ChatSecure can do OMEMO - why not 100% ?

### DIFF
--- a/_data/clients/chatsecure.yml
+++ b/_data/clients/chatsecure.yml
@@ -4,4 +4,4 @@ tracking_issue: "https://github.com/ChatSecure/ChatSecure-iOS/issues/376"
 work_in_progress: yes
 testing: yes
 done: yes
-status: 67
+status: 100


### PR DESCRIPTION
I suggest to set ChatSecure 100% because basically you can use OMEMO and it works. Yes, Push Notification might stuggle but OMEMO works for the moment. https://github.com/ChatSecure/ChatSecure-iOS/issues/376