### PR TITLE
Move boogie chat file into the correct directory

### DIFF
--- a/_data/clients/boogie-chat.yml
+++ b/_data/clients/boogie-chat.yml
@@ -1,0 +1,7 @@
+name: Boogie Chat
+url: https://itunes.apple.com/fi/app/boogie-chat/id779423907?mt=8
+tracking_issue: ""
+work_in_progress: yes
+testing: no
+done: no
+status: 0

--- a/clients/boogie-chat
+++ b/clients/boogie-chat
@@ -1,7 +1,0 @@
-++name: Boogie Chat
-++url: https://itunes.apple.com/fi/app/boogie-chat/id779423907?mt=8
-++tracking_issue: ""
-++work_in_progress: yes
-++testing: no
-++done: no
-++status: 0


### PR DESCRIPTION
@Echolon mentioned in #78 that Boogie Chat isn't visible on the website. I noticed it was put into the wrong directory.