### PR TITLE
Split up clients into sections with individual anchors #40

### DIFF
--- a/_data/clients/conversations.yml
+++ b/_data/clients/conversations.yml
@@ -4,3 +4,4 @@ work_in_progress: yes
 testing: yes
 done: yes
 status: 100
+os_support: [iOS, macOS, Android]

--- a/_includes/client_detail.html
+++ b/_includes/client_detail.html
@@ -1,0 +1,29 @@
+<h3 id="{{ client.name }}">{{ client.name }}</h3>
+<dl class="client_detail">
+    <dt>🌐 Website</dt>
+    <dd>
+        <a href="{{ client.url }}" alt="{{ client.name }} website">{{ client.url }}</a>
+    </dd>
+
+    {% if client.tracking_issue %}
+    <dt>Tracking Issue</dt>
+    <dd>
+        <a href="{{ client.tracking_issue }}">{{client.tracking_issue}}</a>
+    </dd>
+    {% endif %}
+    <dt>Bounty</dt>
+    <dd>
+        {% if client.bountysource %}
+        <a href="https://www.bountysource.com/issues/{{ client.bountysource }}">
+            <img class="nobordernonation" src="https://api.bountysource.com/badge/issue?issue_id={{ client.bountysource }}" />
+        </a>
+        {% else %}<img class="nobordernonation" src="https://img.shields.io/badge/bountysource-none%20yet-orange.svg" />{% endif %}
+    </dd>
+
+    {% if client.os_support %}
+    <dt>OS Support</dt>
+    <dd>
+        {{ client.os_support | array_to_sentence_string }}
+    </dd>
+    {% endif %}
+</dl>

--- a/_includes/client_row.html
+++ b/_includes/client_row.html
@@ -1,0 +1,19 @@
+<tr>
+    <td><a href="#{{ client.name }}" alt="{{ client.name }}">{{ client.name }}</a></td>
+    <td>
+        {% if client.tracking_issue %}
+        <a href="{{ client.tracking_issue }}">✪</a>
+        {% else %}😢{% endif %}
+    </td>
+    <td>
+        {% if client.bountysource %}
+        <a href="https://www.bountysource.com/issues/{{ client.bountysource }}">
+            <img class="nobordernonation" src="https://api.bountysource.com/badge/issue?issue_id={{ client.bountysource }}" />
+        </a>
+        {% else %}<img class="nobordernonation" src="https://img.shields.io/badge/bountysource-none%20yet-orange.svg" />{% endif %}
+    </td>
+
+    <td data-sort="{{ client.status | plus: 0 }}" class="progress">
+        <progress max="100" value="{{ client.status | plus: 0 }}"></progress>
+    </td>
+</tr>

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -110,4 +110,16 @@ table {
         }
     }
 }
+dl.client_detail {
+    border-radius: 8px;
+    padding: 1em;
+    background-color: #f4f4f4;
+    dt {
+        background-color: #f8f8f8;
+        padding: 0.5em;
+    }
+    dd {
+    }
+}
+
 

--- a/index.md
+++ b/index.md
@@ -23,27 +23,15 @@ The last update was **{{ 'now' | date: "%Y-%m-%d" }}**.
 
 {% for client_hash in site.data.clients %}
 {% assign client = client_hash[1] %}
-  <tr>
-    <td><a href="{{ client.url }}" alt="{{ client.name }} website">{{ client.name }}</a></td>
-    <td>
-      {% if client.tracking_issue %}
-      <a href="{{ client.tracking_issue }}">✪</a>
-      {% else %}😢{% endif %}
-    </td>
-    <td>
-      {% if client.bountysource %}
-      <a href="https://www.bountysource.com/issues/{{ client.bountysource }}">
-        <img class="nobordernonation" src="https://api.bountysource.com/badge/issue?issue_id={{ client.bountysource }}" />
-      </a>
-      {% else %}<img class="nobordernonation" src="https://img.shields.io/badge/bountysource-none%20yet-orange.svg" />{% endif %}
-    </td>
-
-    <td data-sort="{{ client.status | plus: 0 }}" class="progress">
-      <progress max="100" value="{{ client.status | plus: 0 }}"></progress>
-    </td>
-  </tr>
-  {% endfor %}
+{% include client_row.html %}
+{% endfor %}
 </table>
+
+# Client Details
+{% for client_hash in site.data.clients %}
+{% assign client = client_hash[1] %}
+{% include client_detail.html %}
+{% endfor %}
 
 #### Alternative OMEMO Plugins
 


### PR DESCRIPTION
This PR will add a new section below the main table that adds a addressable
anchor for every client. Individual details like OS support or plugin /
licensing details can be added down there without cluttering the main table.

Refs #40
Refs #35 

--

@ReneVolution I've taken your PR #85 and split it up into multiple includes. 