### PR TITLE
Update the status of Psi/Psi+ and JSXC

### DIFF
--- a/_data/clients/jsxc.yml
+++ b/_data/clients/jsxc.yml
@@ -3,4 +3,4 @@ url: https://www.jsxc.org/
 tracking_issue: https://github.com/jsxc/jsxc/issues/228
 bountysource: 27207998
 work_in_progress: yes
-status: 33
+status: 66

--- a/_data/clients/psi.yml
+++ b/_data/clients/psi.yml
@@ -1,5 +1,5 @@
 name: Psi
 url: http://psi-im.org/
 work_in_progress: yes
-status: 50
+status: 100
 tracking_issue: https://github.com/psi-im/plugins/issues/10

--- a/_data/clients/psi_plus.yml
+++ b/_data/clients/psi_plus.yml
@@ -1,5 +1,5 @@
 name: Psi+
 work_in_progress: yes
-status: 50
+status: 100
 url: http://psi-plus.com/
 tracking_issue: https://github.com/psi-plus/plugins/issues/10


### PR DESCRIPTION
As psi-im/plugins#29 suggests, @stigger is now finished with the plugin. :tada:

A quick checkup of the tracking issues list also shows that JSXC finally [has a working plugin](https://github.com/jsxc/jsxc-plugin-omemo/commit/5e8a59dab895b9a00cb31820978adf7687a2d512). It's still in alpha, though. [Here's the announcement](https://github.com/jsxc/jsxc/issues/228#issuecomment-358628713) by @sualko. 