### PR TITLE
Added Kadian

### DIFF
--- a/_data/clients/Kaidan
+++ b/_data/clients/Kaidan
@@ -1,0 +1,7 @@
+++name: Kaidan
+++url: https://github.com/KaidanIM/Kaidan
+++tracking_issue: https://github.com/KaidanIM/Kaidan/issues/102
+++work_in_progress: yes
+++testing: no
+++done: no
+++status: 0


### PR DESCRIPTION
> Kaidan is a simple, user-friendly Jabber/XMPP client providing a modern user-interface using Kirigami and QtQuick. The back-end of Kaidan is entirely written in C++ using the gloox XMPP client library and Qt 5.
> 
> Currently Kaidan only has been tested on GNU/Linux Desktops, Android & Plasma Mobile, but of course Ubuntu Touch, OS X, iOS and Windows will follow. Of course this is still not everything, i.e. Sailfish OS is missing. To support that we need to wait for a proper QtQuickControls 2 style for it or rewrite the GUI using Silica. Both options are rather unlikely in the near future, so if you want to get a client for Sailfish OS now, maybe take a look at Shmoose, a fork by an earlier developer of Kaidan.
> 
> Kaidan is not finished yet, so don't expect it working as well as a finished client will do.
> 
> For a list of supported XEPs, have a look at the Wiki.

https://github.com/KaidanIM/Kaidan