### PR TITLE
Move to a more advanced logic for emoji display

### DIFF
--- a/_data/clients/coy_im.yml
+++ b/_data/clients/coy_im.yml
@@ -1,0 +1,7 @@
+---
+name: Coy.im
+url: https://coy.im/
+tracking_issue: https://github.com/coyim/coyim/issues/233#issuecomment-212000432
+declined: yes
+status: 0
+os_support: [Windows,Linux,MacOS]

--- a/_includes/client_detail.html
+++ b/_includes/client_detail.html
@@ -5,6 +5,19 @@
         <a href="{{ client.url }}" alt="{{ client.name }} website">{{ client.url }}</a>
     </dd>
 
+    {% if client.status == 100 %}
+    <dt>Progress</dt>
+    <dd>
+        Hooray! OMEMO is supported!
+    </dd>
+    {% endif %}
+    {% if client.declined %}
+    <dt>Progress</dt>
+    <dd>
+        Sadly, they have decided not to support OMEMO.
+    </dd>
+    {% endif %}
+
     {% if client.tracking_issue %}
     <dt>Tracking Issue</dt>
     <dd>

--- a/_includes/client_row.html
+++ b/_includes/client_row.html
@@ -1,9 +1,12 @@
 <tr>
     <td><a href="#{{ client.name }}" alt="{{ client.name }}">{{ client.name }}</a></td>
     <td>
-        {% if client.tracking_issue %}
-        <a href="{{ client.tracking_issue }}">✪</a>
-        {% else %}😢{% endif %}
+        {% if client.tracking_issue %}<a href="{{ client.tracking_issue }}">{% endif %}
+            {% if client.status == 100 %}🎉
+            {% elsif client.declined %}😭
+            {% elsif client.tracking_issue %}✪
+            {% else %}❓{% endif %}
+        {% if client.tracking_issue %}</a>{% endif %}
     </td>
     <td>
         {% if client.bountysource %}


### PR DESCRIPTION
Now clients will show 1 of 4 different symbols depending on the
situation:
- OMEMO support is completed
- OMEMO support is in progress
- We don't know what the state is (missing public tracker)
- The client has decided to *not* implement OMEMO (?!?!)

Expands on the completion and declined states in a full sentence in the
client details page.

Adds a Coy.im client file both to record the situation and demonstrate
the new crying logic.

Closes #59, #96, #106, #83.