### PR TITLE
empathy: update tracking issue

### DIFF
--- a/_data/clients/empathy.yml
+++ b/_data/clients/empathy.yml
@@ -1,3 +1,3 @@
 name: Empathy
 url: https://wiki.gnome.org/action/show/Apps/Empathy
-tracking_issue: https://bugzilla.gnome.org/show_bug.cgi?id=757029
+tracking_issue: https://gitlab.gnome.org/GNOME/empathy/issues/851


### PR DESCRIPTION
GNOME migrated from Bugzilla to Gitlab, thus the change of the issue URL