### PR TITLE
Delete boogie-chat.yml

### DIFF
--- a/_data/clients/boogie-chat.yml
+++ b/_data/clients/boogie-chat.yml
@@ -1,6 +1,0 @@
-name: Boogie Chat
-url: https://itunes.apple.com/fi/app/boogie-chat/id779423907?mt=8
-work_in_progress: no
-testing: no
-done: no
-status: 0


### PR DESCRIPTION
This client seems to be dead for over a year now with no sense of anything working.

Always possible to bring it back if anyhing changes.