### PR TITLE
Create chatty

### DIFF
--- a/_data/clients/chatty
+++ b/_data/clients/chatty
@@ -1,0 +1,7 @@
+name: Chatty (Purism OS only)
+url: https://puri.sm/
+tracking_issue: "https://puri.sm/posts/librem5-progress-report-19/"     
+work_in_progress: yes   
+testing: yes        
+done: no   
+status: 20


### PR DESCRIPTION
Purism's chat app

"Therefore, as a bonus feature, Chatty is going to support XMPP with OMEMO encryption as well as SMS on day one, instead of only SMS."  https://puri.sm/posts/librem5-progress-report-19/

Works on their phone only and is still under development.