### PR TITLE
Pidgin is not ready

### DIFF
--- a/_data/clients/pidgin.yml
+++ b/_data/clients/pidgin.yml
@@ -4,5 +4,5 @@ tracking_issue: https://developer.pidgin.im/ticket/16801
 bountysource: 28287404
 work_in_progress: yes
 testing: yes
-done: yes
-status: 100
+done: no
+status: 60


### PR DESCRIPTION
Pidgin's OMEMO functionality is provided by a "highly experimental" plugin and full functionality requires another experimental plugin for Carbons. See https://github.com/bascht/omemo-top/issues/127.