### PR TITLE
Add OS support

### DIFF
--- a/_data/clients/adium.yml
+++ b/_data/clients/adium.yml
@@ -3,3 +3,4 @@ url: https://adium.im/
 tracking_issue: "https://trac.adium.im/ticket/17090"
 testing: yes
 status: 50
+os_support: [macOS]

--- a/_data/clients/beagleim.yml
+++ b/_data/clients/beagleim.yml
@@ -4,4 +4,4 @@ tracking_issue: "https://tigase.tech/issues/8837"
 work_in_progress: yes   
 done: no   
 status: 0
-os_support: [MacOS]
+os_support: [macOS]

--- a/_data/clients/bitlbee.yml
+++ b/_data/clients/bitlbee.yml
@@ -2,3 +2,4 @@ name: BitlBee
 url: https://www.bitlbee.org/
 tracking_issue: https://bugs.bitlbee.org/ticket/1239
 bountysource: 47491511
+os_support: [BSD,Linux]

--- a/_data/clients/candy.yml
+++ b/_data/clients/candy.yml
@@ -1,3 +1,4 @@
 name: Candy
 url: https://candy-chat.github.io/candy/
 tracking_issue: https://github.com/candy-chat/candy/issues/480
+os_support: [Browser]

--- a/_data/clients/chatsecure.yml
+++ b/_data/clients/chatsecure.yml
@@ -5,3 +5,4 @@ work_in_progress: yes
 testing: yes
 done: yes
 status: 67
+os_support: [iOS]

--- a/_data/clients/conversations_legacy.yml
+++ b/_data/clients/conversations_legacy.yml
@@ -4,3 +4,4 @@ work_in_progress: no
 testing: no
 done: yes
 status: 100
+os_support: [Android]

--- a/_data/clients/converse_js.yml
+++ b/_data/clients/converse_js.yml
@@ -6,3 +6,4 @@ work_in_progress: yes
 testing: yes
 done: yes
 status: 100
+os_support: [Browser]

--- a/_data/clients/coy_im.yml
+++ b/_data/clients/coy_im.yml
@@ -1,7 +1,6 @@
----
 name: Coy.im
 url: https://coy.im/
 tracking_issue: https://github.com/coyim/coyim/issues/233#issuecomment-212000432
 declined: yes
 status: 0
-os_support: [Windows,Linux,MacOS]
+os_support: [Linux,macOS,Windows]

--- a/_data/clients/empathy.yml
+++ b/_data/clients/empathy.yml
@@ -1,3 +1,4 @@
 name: Empathy
 url: https://wiki.gnome.org/action/show/Apps/Empathy
 tracking_issue: https://gitlab.gnome.org/GNOME/empathy/issues/851
+os_support: [Linux]

--- a/_data/clients/eyecu.yml
+++ b/_data/clients/eyecu.yml
@@ -5,3 +5,4 @@ work_in_progress: no
 testing: no
 done: no
 status: 0
+os_support: [Linux,OS/2,Windows]

--- a/_data/clients/finch.yml
+++ b/_data/clients/finch.yml
@@ -3,3 +3,4 @@ url: https://developer.pidgin.im/wiki/Using%20Finch
 work_in_progress: yes
 testing: yes
 status: 67
+os_support: [Linux]

--- a/_data/clients/gajim.yml
+++ b/_data/clients/gajim.yml
@@ -5,4 +5,4 @@ work_in_progress: yes
 testing: yes
 done: yes
 status: 100
-os_support: [Linux]
+os_support: [BSD,Linux,Windows]

--- a/_data/clients/implus.yml
+++ b/_data/clients/implus.yml
@@ -4,3 +4,4 @@ work_in_progress: no
 testing: no
 done: no
 status: 0
+os_support: [Android,BlackBerry OS,iOS]

--- a/_data/clients/instantbird.yml
+++ b/_data/clients/instantbird.yml
@@ -1,3 +1,4 @@
 name: Instantbird
 url: http://www.instantbird.com/
 tracking_issue: https://developer.pidgin.im/ticket/16801
+os_support: [Linux,macOS,Windows]

--- a/_data/clients/irssi.yml
+++ b/_data/clients/irssi.yml
@@ -1,3 +1,4 @@
 name: Irssi
 url: http://cybione.org/~irssi-xmpp/
 tracking_issue: https://github.com/cdidier/irssi-xmpp/issues/8
+os_support: [BSD,Linux]

--- a/_data/clients/jackline.yml
+++ b/_data/clients/jackline.yml
@@ -2,3 +2,4 @@ name: Jackline
 url: https://github.com/hannesm/jackline
 tracking_issue: https://github.com/hannesm/jackline/issues/153
 bountysource: 41164178
+os_support: [BSD,macOS]

--- a/_data/clients/jappix.yml
+++ b/_data/clients/jappix.yml
@@ -1,3 +1,4 @@
 name: Jappix
-url: https://jappix.org/
+url: https://github.com/jappix/jappix
 tracking_issue: https://github.com/jappix/jappix/issues/305
+os_support: [Browser]

--- a/_data/clients/jsxc.yml
+++ b/_data/clients/jsxc.yml
@@ -1,6 +1,7 @@
 name: JSXC
-url: https://www.jsxc.org/
+url: https://github.com/jsxc/jsxc
 tracking_issue: https://github.com/jsxc/jsxc/issues/228
 bountysource: 27207998
 work_in_progress: yes
 status: 66
+os_support: [Browser]

--- a/_data/clients/kaidan.yml
+++ b/_data/clients/kaidan.yml
@@ -1,7 +1,8 @@
 name: Kaidan
-url: https://git.kaidan.im/kaidan/kaidan
+url: https://www.kaidan.im/
 tracking_issue: https://git.kaidan.im/kaidan/kaidan/issues/254
 work_in_progress: yes
 testing: no
 done: no
 status: 0
+os_support: [Android,Linux,Windows]

--- a/_data/clients/kaiwa.yml
+++ b/_data/clients/kaiwa.yml
@@ -2,3 +2,4 @@ name: Kaiwa
 url: http://getkaiwa.com/
 tracking_issue: https://github.com/digicoop/kaiwa/issues/63
 bountysource: 27208012
+os_support: [Browser]

--- a/_data/clients/kontalk.yml
+++ b/_data/clients/kontalk.yml
@@ -2,3 +2,4 @@ name: Kontalk
 url: https://kontalk.org/
 tracking_issue: "https://github.com/kontalk/androidclient/issues/132"
 bountysource: 18980767
+os_support: [Android,Linux,macOS,Windows]

--- a/_data/clients/mcabber.yml
+++ b/_data/clients/mcabber.yml
@@ -1,3 +1,4 @@
 name: Mcabber
 url: https://mcabber.com/
 tracking_issue: https://bitbucket.org/McKael/mcabber-crew/issues/156
+os_support: [BSD,Linux,macOS]

--- a/_data/clients/miranda-im.yml
+++ b/_data/clients/miranda-im.yml
@@ -1,3 +1,4 @@
 name: Miranda IM
 url: http://www.miranda-im.org/
 tracking_issue: "https://sourceforge.net/p/miranda/tickets/1764/"
+os_support: [Windows]

--- a/_data/clients/miranda_ng.yml
+++ b/_data/clients/miranda_ng.yml
@@ -6,3 +6,4 @@ work_in_progress: yes
 testing: yes
 done: yes
 status: 100
+os_support: [Windows]

--- a/_data/clients/monal.yml
+++ b/_data/clients/monal.yml
@@ -6,3 +6,4 @@ work_in_progress: yes
 testing: yes
 done: yes
 status: 100
+os_support: [iOS,macOS]

--- a/_data/clients/movim.yml
+++ b/_data/clients/movim.yml
@@ -4,3 +4,4 @@ tracking_issue: https://github.com/movim/movim/issues/63
 bountysource: 27538550
 work_in_progress: no
 status: 0
+os_support: [Android,Linux,macOS,Windows]

--- a/_data/clients/pidgin.yml
+++ b/_data/clients/pidgin.yml
@@ -6,3 +6,4 @@ work_in_progress: yes
 testing: yes
 done: no
 status: 60
+os_support: [Linux,macOS,Windows]

--- a/_data/clients/pix-art.yml
+++ b/_data/clients/pix-art.yml
@@ -4,3 +4,4 @@ work_in_progress: yes
 testing: yes
 done: yes
 status: 100
+os_support: [Android]

--- a/_data/clients/poezio.yml
+++ b/_data/clients/poezio.yml
@@ -1,3 +1,4 @@
 name: Poezio
 url: https://poez.io/
 tracking_issue: https://lab.louiz.org/poezio/poezio/issues/3280
+os_support: [BSD,Linux]

--- a/_data/clients/profanity.yml
+++ b/_data/clients/profanity.yml
@@ -5,3 +5,4 @@ bountysource: 27781988
 work_in_progress: yes
 testing: yes
 status: 100
+os_support: [BSD,Linux,macOS]

--- a/_data/clients/psi.yml
+++ b/_data/clients/psi.yml
@@ -4,3 +4,4 @@ work_in_progress: yes
 status: 100
 done: yes
 tracking_issue: https://github.com/psi-im/plugins/issues/10
+os_support: [macOS,Windows]

--- a/_data/clients/psi_plus.yml
+++ b/_data/clients/psi_plus.yml
@@ -4,3 +4,4 @@ status: 100
 done: yes
 url: http://psi-plus.com/
 tracking_issue: https://github.com/psi-plus/plugins/issues/10
+os_support: [Haiku,Linux,macOS,Windows]

--- a/_data/clients/salut_a_toi.yml
+++ b/_data/clients/salut_a_toi.yml
@@ -4,4 +4,4 @@ tracking_issue: https://bugs.goffi.org/show_bug.cgi?id=180
 work_in_progress: yes
 done: no
 status: 70
-os_support: [Linux,BSD,Windows,MacOS,Android(WIP)]
+os_support: [Android(WIP),BSD,Linux,macOS,Windows]

--- a/_data/clients/spark.yml
+++ b/_data/clients/spark.yml
@@ -1,3 +1,4 @@
 name: Spark
 url: https://igniterealtime.org/projects/spark/
-tracking_issue: https://github.com/igniterealtime/Spark/issues/291
+tracking_issue: https://issues.igniterealtime.org/browse/SPARK-1866
+os_support: [Linux,macOS,Windows]

--- a/_data/clients/stanzaio.yml
+++ b/_data/clients/stanzaio.yml
@@ -1,3 +1,4 @@
 name: Stanza.io
 url: https://stanza.io
 tracking_issue: https://github.com/legastero/stanza.io/issues/216
+os_support: [Browser]

--- a/_data/clients/swift.yml
+++ b/_data/clients/swift.yml
@@ -3,4 +3,4 @@ url: https://swift.im/
 tracking_issue: https://github.com/swift/swift/issues/37
 declined: yes
 status: 0
-os_support: [Windows,Linux,MacOS]
+os_support: [Linux,macOS,Windows]

--- a/_data/clients/thunderbird.yml
+++ b/_data/clients/thunderbird.yml
@@ -2,3 +2,4 @@ name: Thunderbird (Chat Core)
 url: https://developer.mozilla.org/docs/Chat_Core
 tracking_issue: https://bugzilla.mozilla.org/show_bug.cgi?id=1237416
 bountysource: 29687088
+os_support: [Linux,macOS,Windows]

--- a/_data/clients/tkabber.yml
+++ b/_data/clients/tkabber.yml
@@ -4,3 +4,4 @@ work_in_progress: no
 testing: no
 done: no
 status: 0
+os_support: [BSD,Linux,macOS,Solaris,Windows]

--- a/_data/clients/tor_messenger.yml
+++ b/_data/clients/tor_messenger.yml
@@ -1,3 +1,4 @@
 name: Tor Messenger
 url: https://trac.torproject.org/projects/tor/wiki/doc/TorMessenger
 tracking_issue: https://trac.torproject.org/projects/tor/ticket/17457
+os_support: [Linux,macOS]

--- a/_data/clients/vacuum-im.yml
+++ b/_data/clients/vacuum-im.yml
@@ -5,3 +5,4 @@ work_in_progress: no
 testing: no
 done: no
 status: 0
+os_support: [macOS,Windows]

--- a/_data/clients/xabber.yml
+++ b/_data/clients/xabber.yml
@@ -4,3 +4,4 @@ tracking_issue: "https://github.com/redsolution/xabber-android/issues/540"
 declined: yes
 status: 0
 bountysource: 26498485
+os_support: [Android]

--- a/_data/clients/yaxim.yml
+++ b/_data/clients/yaxim.yml
@@ -1,3 +1,4 @@
 name: yaxim
 url: https://yaxim.org/
 tracking_issue: https://github.com/pfleidi/yaxim/issues/197
+os_support: [Android]

--- a/_data/clients/zom.yml
+++ b/_data/clients/zom.yml
@@ -4,3 +4,4 @@ tracking_issue: https://github.com/zom/Zom-Android/issues/119
 work_in_progress: yes
 bountysource: 36057445
 status: 100
+os_support: [Android,iOS]


### PR DESCRIPTION
Added OS support for many projects (usually only native support or ports, not with emulators)
Fixed MacOS to macOS (this is an official name for quite some time)
Sorted OS list alphabetically (same as https://xmpp.org/software/clients.html does)
Added new type - Browser (same as https://xmpp.org/software/clients.html)
Replaced a few dead links to project pages with GitHub links