### PR TITLE
Add Conversations with IPv6

### DIFF
--- a/_data/clients/conv6.yml
+++ b/_data/clients/conv6.yml
@@ -1,0 +1,7 @@
+name: Conversations with IPv6
+url: https://f-droid.org/en/packages/eu.sum7.conversations
+work_in_progress: yes
+testing: yes
+done: yes
+status: 100
+os_support: [Android]


### PR DESCRIPTION
A Conversations fork from chat.sum7.eu which removed hardcoded preferred IPv4 support