### PR TITLE
Remove Zom IM

### DIFF
--- a/_data/clients/zom.yml
+++ b/_data/clients/zom.yml
@@ -1,7 +1,0 @@
-name: Zom
-url: https://zom.im/
-tracking_issue: https://github.com/zom/Zom-Android/issues/119
-work_in_progress: yes
-bountysource: 36057445
-status: 100
-os_support: [Android,iOS]


### PR DESCRIPTION
The Zom project switched from XMPP to Matrix, so Zom XMPP has been discontinued
https://github.com/zom/Zom-Android-XMPP