### PR TITLE
Update dino.yml

### DIFF
--- a/_data/clients/dino.yml
+++ b/_data/clients/dino.yml
@@ -4,6 +4,6 @@ tracking_issue: https://github.com/dino/dino/issues/36
 bountysource: 44025760
 work_in_progress: yes
 testing: yes
-done: no
-status: 85
-os_support: [Linux]
+done: yes
+status: 100
+os_support: [BSD,Linux]


### PR DESCRIPTION
The OMEMO implementation in Dino is considered finished (dino/dino#36 is closed, some bugs might still exist). Also support for FreeBSD was added.