### PR TITLE
Update poezio status

### DIFF
--- a/_data/clients/poezio.yml
+++ b/_data/clients/poezio.yml
@@ -2,3 +2,7 @@ name: Poezio
 url: https://poez.io/
 tracking_issue: https://lab.louiz.org/poezio/poezio/issues/3280
 os_support: [BSD,Linux]
+work_in_progress: yes
+testing: yes
+done: no
+status: 30


### PR DESCRIPTION
Initial support (encrypting/decrypting messages, publishing bundles) is available in poezio master with the poezio-omemo plugin: https://lab.louiz.org/poezio/poezio-omemo

There is still a lot of work to make it acceptable for secure usage, but at least it can communicate with OMEMO device.