### PR TITLE
Remove "Conversations Legacy"

### DIFF
--- a/_data/clients/conversations_legacy.yml
+++ b/_data/clients/conversations_legacy.yml
@@ -1,7 +1,0 @@
-name: Conversations Legacy
-url: https://play.google.com/store/apps/details?id=eu.siacs.conversations.legacy
-work_in_progress: no
-testing: no
-done: yes
-status: 100
-os_support: [Android]


### PR DESCRIPTION
Conversations Legacy has been discontinued and taken down from the Play Store