### PR TITLE
Set Xabber Web to 100%

### DIFF
--- a/_data/clients/xabber_web.yml
+++ b/_data/clients/xabber_web.yml
@@ -2,4 +2,4 @@ name: Xabber Web
 url: https://web.xabber.com
 tracking_issue: https://github.com/redsolution/xabber-web/issues/3
 work_in_progress: no
-status: 0
+status: 100


### PR DESCRIPTION
Xabber Web appears to have implemented OMEMO [1] for both private chats and MUCs, based on commit [2]. Sadly, the version with OMEMO doesn't seem to be released yet, but the `feature/OMEMO` branch has already been merged to their `develop`.

[1]: https://github.com/redsolution/xabber-web/compare/2.1.0...feature/OMEMO
[2]: https://github.com/redsolution/xabber-web/commit/4f1ea6587eb17c83f5e5dab8f70c07acadc02855