### PR TITLE
Remove unmaintained for a long time TorMessenger

### DIFF
--- a/_data/clients/tor_messenger.yml
+++ b/_data/clients/tor_messenger.yml
@@ -1,4 +1,0 @@
-name: Tor Messenger
-url: https://trac.torproject.org/projects/tor/wiki/doc/TorMessenger
-tracking_issue: https://trac.torproject.org/projects/tor/ticket/17457
-os_support: [Linux,macOS]


### PR DESCRIPTION
From the project's [wiki](https://gitlab.torproject.org/legacy/trac/-/wikis/doc/TorMessenger): "As of March 2018, Tor Messenger is NO LONGER MAINTAINED and you should NOT use it".