### PR TITLE
Add Haiku XMPP clients

### DIFF
--- a/_data/clients/chat-o-matic.yml
+++ b/_data/clients/chat-o-matic.yml
@@ -1,0 +1,7 @@
+name: Chat-O-Matic
+url: https://github.com/JadedCtrl/Chat-O-Matic
+work_in_progress: no
+testing: no
+done: no
+status: 0
+os_support: [Haiku]

--- a/_data/clients/renga.yml
+++ b/_data/clients/renga.yml
@@ -1,0 +1,7 @@
+name: Renga
+url: https://github.com/HaikuArchives/Renga
+work_in_progress: no
+testing: no
+done: no
+status: 0
+os_support: [Haiku]


### PR DESCRIPTION
There are two promising clients for Haiku: [Renga](https://github.com/HaikuArchives/Renga) and [Chat-O-Matic](https://github.com/JadedCtrl/Chat-O-Matic) (libpurple-based). Sadly, both of them currently don't have OMEMO support.