### PR TITLE
Fix Opa's URL

### DIFF
--- a/_data/clients/opa.yml
+++ b/_data/clients/opa.yml
@@ -1,5 +1,5 @@
 name: Opa     
-url: https://www.credija.com.br/opa-demo/    
+url: https://github.com/credija/opa    
 tracking_issue: "https://github.com/credija/opa/issues/24"             
 work_in_progress: yes        
 testing: yes            


### PR DESCRIPTION
Old URL died [in 2020](https://github.com/credija/opa/issues/62) (or even earlier) and now redirects to something completely different.