### PR TITLE
RIP, anderChat

### DIFF
--- a/_data/clients/anderchat.yml
+++ b/_data/clients/anderchat.yml
@@ -1,2 +1,0 @@
-name: Anderchat
-url: https://www.anderscore.com/leistungen/anderchat/


### PR DESCRIPTION
anderChat can safely be deleted. Homepage and Google Play [link](https://play.google.com/store/apps/details?id=com.anderscore.anderchat) are no longer available.

From the remaining APKPure [page](https://apkpure.com/anderchat-messenger-beta/com.anderscore.anderchat): "Dear User, we will remove this entry from the Play Store at August 18 2017".