### PR TITLE
Delete tigase-android-messenger.yml

### DIFF
--- a/_data/clients/tigase-android-messenger.yml
+++ b/_data/clients/tigase-android-messenger.yml
@@ -1,7 +1,0 @@
-name: Tigase Android Messenger
-url: https://tigase.tech/projects/tigase-mobilemessenger
-tracking_issue: "https://tigase.tech/issues/8838"
-work_in_progress: yes   
-done: no   
-status: 0
-os_support: [Android]


### PR DESCRIPTION
It's now called Stork IM (and we already have Stork IM), see [this](https://gitlab.com/fdroid/fdroiddata/-/merge_requests/6827) merge request. IzzyOnDroid repo also [states](https://android.izzysoft.de/repo/apk/org.tigase.messenger.phone.pro) that Stork IM "formerly known as Tigase Messenger".