### PR TITLE
Fix Miranda's URL

### DIFF
--- a/_data/clients/miranda-im.yml
+++ b/_data/clients/miranda-im.yml
@@ -1,4 +1,4 @@
 name: Miranda IM
-url: http://www.miranda-im.org/
+url: https://sourceforge.net/projects/miranda/
 tracking_issue: "https://sourceforge.net/p/miranda/tickets/1764/"
 os_support: [Windows]


### PR DESCRIPTION
Wayback Machine tells that website stopped working in late 2019.