### PR TITLE
Small fixes

### DIFF
--- a/_data/clients/eyecu.yml
+++ b/_data/clients/eyecu.yml
@@ -1,6 +1,6 @@
 name: EyeCU
 url: http://eyecu.ru
-tracking_issue: https://github.com/RoadWorksSoftware/eyecu-qt/issues/44
+tracking_issue: https://gitlab.com/rwsoftware/eyecu-qt/-/issues/44
 work_in_progress: no
 testing: no
 done: no

--- a/_data/clients/gajim.yml
+++ b/_data/clients/gajim.yml
@@ -5,4 +5,4 @@ work_in_progress: yes
 testing: yes
 done: yes
 status: 100
-os_support: [BSD,Linux,Windows]
+os_support: [BSD,Linux,macOS,Windows]

--- a/_data/clients/irssi.yml
+++ b/_data/clients/irssi.yml
@@ -1,4 +1,4 @@
-name: Irssi
-url: http://cybione.org/~irssi-xmpp/
+name: Irssi (XMPP plugin)
+url: https://github.com/cdidier/irssi-xmpp
 tracking_issue: https://github.com/cdidier/irssi-xmpp/issues/8
 os_support: [BSD,Linux]

--- a/_data/clients/miranda_ng.yml
+++ b/_data/clients/miranda_ng.yml
@@ -1,5 +1,5 @@
 name: Miranda NG
-url: http://www.miranda-ng.org/
+url: https://www.miranda-ng.org/
 tracking_issue: https://github.com/miranda-ng/miranda-ng/issues/529
 bountysource: 32298989
 work_in_progress: yes

--- a/_data/clients/pidgin.yml
+++ b/_data/clients/pidgin.yml
@@ -6,4 +6,4 @@ work_in_progress: yes
 testing: yes
 done: no
 status: 60
-os_support: [Linux,macOS,Windows]
+os_support: [BSD,Linux,macOS,Windows]

--- a/_data/clients/psi_plus.yml
+++ b/_data/clients/psi_plus.yml
@@ -2,6 +2,6 @@ name: Psi+
 work_in_progress: yes
 status: 100
 done: yes
-url: http://psi-plus.com/
+url: https://psi-plus.com/
 tracking_issue: https://github.com/psi-plus/plugins/issues/10
 os_support: [Haiku,Linux,macOS,Windows]


### PR DESCRIPTION
Gajim [works on MacOS, but there is no package yet.](https://gajim.org/download/)

Homepage of irssi-xmpp redirects to GitHub since 2020. Also I think we should specify that it's not irssi itself, but merely a plugin.