### PR TITLE
SleekXMPP is deprecated

### DIFF
--- a/index.md
+++ b/index.md
@@ -40,6 +40,7 @@ The last update was **{{ 'now' | date: "%Y-%m-%d" }}**.
 
 #### Libraries
 
+* Deprecated: [SleekXMPP](https://github.com/fritzy/SleekXMPP) ([OMEMO](https://gitlab.com/ecartman/sleekxmpp-omemo-plugin))
 * [Slixmpp](https://lab.louiz.org/poezio/slixmpp) ([OMEMO](https://lab.louiz.org/poezio/slixmpp-omemo))
 * [Smack](https://github.com/igniterealtime/Smack) ([OMEMO](https://github.com/igniterealtime/Smack/tree/master/smack-omemo))
 

--- a/index.md
+++ b/index.md
@@ -40,7 +40,6 @@ The last update was **{{ 'now' | date: "%Y-%m-%d" }}**.
 
 #### Libraries
 
-* [SleekXMPP](http://sleekxmpp.com) ([OMEMO](https://gitlab.com/ecartman/sleekxmpp-omemo-plugin))
 * [Slixmpp](https://lab.louiz.org/poezio/slixmpp) ([OMEMO](https://lab.louiz.org/poezio/slixmpp-omemo))
 * [Smack](https://github.com/igniterealtime/Smack) ([OMEMO](https://github.com/igniterealtime/Smack/tree/master/smack-omemo))
 


### PR DESCRIPTION
From the archived [official repo](https://github.com/fritzy/SleekXMPP): "SleekXMPP is deprecated in favor of Slixmpp, a fork which takes full advantage of Python 3 and asyncio". We have Slixmpp in the Libraries section, so no other changes are needed.