### PR TITLE
Fix status of Miranda NG

### DIFF
--- a/_data/clients/miranda_ng.yml
+++ b/_data/clients/miranda_ng.yml
@@ -4,6 +4,6 @@ tracking_issue: https://github.com/miranda-ng/miranda-ng/issues/529
 bountysource: 32298989
 work_in_progress: yes
 testing: yes
-done: yes
-status: 100
+done: no
+status: 84
 os_support: [Windows]


### PR DESCRIPTION
Closes #187

I tested latest stable version of Miranda NG (0.95.13.1) with Conversations 2.10.2+fcr. Clients can talk with each other only without encryption, despite OMEMO being enabled in Miranda's settings.

Sending OMEMO message to Miranda NG fails with "I sent you an OMEMO encrypted message but your client doesn’t seem to support that".

Sending it from Miranda NG to Conversations results in "Delivery failure: No valid OMEMO session exists" error.

So apparently [this](https://github.com/miranda-ng/miranda-ng/issues/1255#issuecomment-390143505) is still not resolved.

Given that there's also [no UI](https://github.com/miranda-ng/miranda-ng/issues/1255) for OMEMO in Miranda NG, let's drop it's progress at least to 84%.