### PR TITLE
Delete dead and unmaintained Candy

### DIFF
--- a/_data/clients/candy.yml
+++ b/_data/clients/candy.yml
@@ -1,4 +1,0 @@
-name: Candy
-url: https://candy-chat.github.io/candy/
-tracking_issue: https://github.com/candy-chat/candy/issues/480
-os_support: [Browser]


### PR DESCRIPTION
["This project is dead and not maintained anymore".](https://github.com/candy-chat/candy/commit/9ac409e3c1082bf6940b3a0974d6b90b8dcbffdc)

Development [stopped](https://github.com/candy-chat/candy/commits/master) in 2016.