### PR TITLE
Fix statuses of Psi and Psi+

### DIFF
--- a/_data/clients/psi.yml
+++ b/_data/clients/psi.yml
@@ -1,7 +1,7 @@
 name: Psi
 url: https://psi-im.org/
+tracking_issue: https://github.com/psi-im/plugins/issues/84
 work_in_progress: yes
-status: 100
-done: yes
-tracking_issue: https://github.com/psi-im/plugins/issues/10
+done: no
+status: 84
 os_support: [Linux,macOS,Windows]

--- a/_data/clients/psi_plus.yml
+++ b/_data/clients/psi_plus.yml
@@ -1,7 +1,7 @@
 name: Psi+
-work_in_progress: yes
-status: 100
-done: yes
 url: https://psi-plus.com/
-tracking_issue: https://github.com/psi-plus/plugins/issues/10
+tracking_issue: https://github.com/psi-im/plugins/issues/84
+work_in_progress: yes
+done: no
+status: 84
 os_support: [Haiku,Linux,macOS,Windows]


### PR DESCRIPTION
Closes #257

Psi and Psi+ should repair file encryption in long-awaited 2.0, but for now I dropped `status` to 84% for both clients.