### PR TITLE
Tkabber's site is gone

### DIFF
--- a/_data/clients/tkabber.yml
+++ b/_data/clients/tkabber.yml
@@ -1,5 +1,5 @@
 name: Tkabber
-url: http://tkabber.jabber.ru/
+url: https://chiselapp.com/user/sgolovan/repository/tkabber
 work_in_progress: no
 testing: no
 done: no


### PR DESCRIPTION
It has been broken since 2022, just checked on Wayback Machine. Now old URL contains something irrelevant. I added a link to Tkabber's repository from [Wikipedia page](https://en.wikipedia.org/wiki/Tkabber) instead.