### PR TITLE
Remove unmaintained Kaiwa

### DIFF
--- a/_data/clients/kaiwa.yml
+++ b/_data/clients/kaiwa.yml
@@ -1,4 +1,0 @@
-name: Kaiwa
-url: http://getkaiwa.com/
-tracking_issue: https://github.com/digicoop/kaiwa/issues/63
-os_support: [Browser]


### PR DESCRIPTION
Kaiwa's website is dead. The client itself is officially unmaintained since 2017 and has only [two commits](https://github.com/getkaiwa/kaiwa/commits/master/) since 2015.