### PR TITLE
Remove discontinued Conv6ations

### DIFF
--- a/_data/clients/conv6ations.yml
+++ b/_data/clients/conv6ations.yml
@@ -1,6 +1,0 @@
-name: Conv6ations (Conversations fork that prefers IPv6)
-url: https://dev.sum7.eu/sum7/Conversations
-work_in_progress: yes   
-done: yes  
-status: 100 
-os_support: [Android]


### PR DESCRIPTION
Conv6ations archived on F-Droid with [comment](https://gitlab.com/fdroid/fdroiddata/-/merge_requests/10393#note_808818800) from author: "My patches lives in blabber.im — i am not willing to maintain this Conversations fork anymore".

Conference room also states: "Conv6ations was archived. It had mainly three changes: color, using chat.sum7.eu as server and patching a preference of ipv4 away. This patch is in blabber.im — just for color and default server name I do not need to maintain a fork".