### PR TITLE
Add Squawk

### DIFF
--- a/_data/clients/squawk.yml
+++ b/_data/clients/squawk.yml
@@ -1,0 +1,7 @@
+name: Squawk
+url: https://macaw.me/projects/squawk/
+tracking_issue: https://git.macaw.me/blue/squawk/issues/71
+work_in_progress: yes
+done: no
+status: 60
+os_support: [Linux]


### PR DESCRIPTION
[Squawk](https://macaw.me/projects/squawk/) is a very promising new Qt-based XMPP client, OMEMO support [is being worked on](https://chat.macaw.me/node/news.macaw.me/squawk/ef6a4a28-e324-44c4-94b7-69e74d4ff525). I listed only Linux as supported OS because README [says](https://git.macaw.me/blue/squawk#for-windows-mingw-w64-build) the Windows version "probably won't work" for now.