### PR TITLE
Add Aparté

### DIFF
--- a/_data/clients/aparte.yml
+++ b/_data/clients/aparte.yml
@@ -1,0 +1,6 @@
+name: Aparté
+url: https://github.com/paulfariello/aparte
+work_in_progress: yes
+done: no
+status: 84
+os_support: [Linux]


### PR DESCRIPTION
[Aparté](https://github.com/paulfariello/aparte) is a "simple XMPP console client written in Rust and inspired by Profanity". It supports OMEMO, but not in MUCs for now, so I set status to 84.