### PR TITLE
Add Moxxy

### DIFF
--- a/_data/clients/moxxy.yml
+++ b/_data/clients/moxxy.yml
@@ -1,0 +1,7 @@
+name: Moxxy
+url: https://moxxy.org
+tracking_issue: https://codeberg.org/moxxy/moxxy/issues/315
+work_in_progress: yes
+done: no
+status: 84
+os_support: [Android]


### PR DESCRIPTION
Another XMPP client for Android, not based on Conversations this time. OMEMO is supported, but not in groupchats yet, according to [this issue](https://codeberg.org/moxxy/moxxy/issues/315).